### PR TITLE
feat(@chill-viking/layout): add header section

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/apps/chill-viking-ng-libs/src/app/app.component.html
+++ b/apps/chill-viking-ng-libs/src/app/app.component.html
@@ -1,3 +1,6 @@
-<cv-layout>
-  <h1>Welcome {{ title }}</h1>
+<cv-layout [data]="data">
+  <ng-template cvHeader let-header>
+    <h1>Welcome {{ header.title$ | async }}</h1>
+  </ng-template>
+  <p>content</p>
 </cv-layout>

--- a/apps/chill-viking-ng-libs/src/app/app.component.spec.ts
+++ b/apps/chill-viking-ng-libs/src/app/app.component.spec.ts
@@ -21,13 +21,4 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app.title).toEqual('chill-viking-ng-libs');
   });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(
-      'Welcome chill-viking-ng-libs'
-    );
-  });
 });

--- a/apps/chill-viking-ng-libs/src/app/app.component.ts
+++ b/apps/chill-viking-ng-libs/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { LayoutContext } from '@chill-viking/layout';
+import { of } from 'rxjs';
 
 @Component({
   selector: 'ng-libs-root',
@@ -7,4 +9,9 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'chill-viking-ng-libs';
+  data: LayoutContext = {
+    header: {
+      title$: of(this.title),
+    },
+  };
 }

--- a/libs/layout/src/index.ts
+++ b/libs/layout/src/index.ts
@@ -1,2 +1,4 @@
 export * from './lib/chill-viking-layout.module';
 export * from './lib/components';
+export * from './lib/directives';
+export * from './lib/models';

--- a/libs/layout/src/lib/chill-viking-layout.module.ts
+++ b/libs/layout/src/lib/chill-viking-layout.module.ts
@@ -1,10 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { HeaderDirective } from './directives/header.directive';
 import { ChillVikingLayoutComponent } from './layout/chill-viking-layout.component';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ChillVikingLayoutComponent],
-  exports: [ChillVikingLayoutComponent],
+  declarations: [ChillVikingLayoutComponent, HeaderDirective],
+  exports: [ChillVikingLayoutComponent, HeaderDirective],
 })
 export class ChillVikingLayoutModule {}

--- a/libs/layout/src/lib/directives.ts
+++ b/libs/layout/src/lib/directives.ts
@@ -1,0 +1,1 @@
+export * from './directives/header.directive';

--- a/libs/layout/src/lib/directives/header.directive.spec.ts
+++ b/libs/layout/src/lib/directives/header.directive.spec.ts
@@ -1,0 +1,66 @@
+import { ChangeDetectionStrategy, Component, ContentChild, TemplateRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LayoutHeaderContext } from '@chill-viking/layout';
+import { of } from 'rxjs';
+import { HeaderDirective } from './header.directive';
+
+@Component({
+  selector: 'cv-layout-header-renderer',
+  template: `
+    <div id="template-render-block">
+      <ng-container
+        [ngTemplateOutlet]="template"
+        [ngTemplateOutletContext]="{ $implicit: ctx }"
+      ></ng-container>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class LayoutHeaderRendererComponent {
+  @ContentChild(HeaderDirective, { read: TemplateRef<LayoutHeaderContext> })
+  template!: TemplateRef<LayoutHeaderContext>;
+  ctx: LayoutHeaderContext = {
+    title$: of('hello'),
+  };
+}
+
+@Component({
+  template: ` <cv-layout-header-renderer>
+    <ng-template cvHeader let-header>
+      <p>{{ header.title$ | async }}</p>
+    </ng-template>
+  </cv-layout-header-renderer>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {}
+
+describe('HeaderDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        HeaderDirective,
+        HostComponent,
+        LayoutHeaderRendererComponent,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    // if component can be created, then directive also created.
+    expect(component).toBeTruthy();
+  });
+
+  it('should be rendered correctly in component', () => {
+    const element = fixture.nativeElement;
+    expect(element.querySelector('#template-render-block').innerHTML).toContain(
+      '<p>hello</p>',
+    );
+  });
+});

--- a/libs/layout/src/lib/directives/header.directive.ts
+++ b/libs/layout/src/lib/directives/header.directive.ts
@@ -1,0 +1,31 @@
+import { Directive, ElementRef, EmbeddedViewRef, Injector, TemplateRef } from '@angular/core';
+import { AsImplicit } from '../models/as-implicit';
+import { LayoutHeaderContext } from '../models/layout-header-context';
+
+export type HeaderDirectiveTemplateContext = AsImplicit<LayoutHeaderContext>;
+
+@Directive({
+  selector: 'ng-template[cvHeader]',
+})
+export class HeaderDirective extends TemplateRef<HeaderDirectiveTemplateContext> {
+  constructor(
+    private _templateRef: TemplateRef<HeaderDirectiveTemplateContext>,
+    public readonly elementRef: ElementRef,
+  ) {
+    super();
+  }
+
+  static ngTemplateContextGuard(
+    template: TemplateRef<HeaderDirectiveTemplateContext>,
+    context: unknown,
+  ): context is HeaderDirectiveTemplateContext {
+    return true;
+  }
+
+  createEmbeddedView(
+    context: HeaderDirectiveTemplateContext,
+    injector: Injector | undefined,
+  ): EmbeddedViewRef<HeaderDirectiveTemplateContext> {
+    return this._templateRef.createEmbeddedView(context, injector);
+  }
+}

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.css
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.css
@@ -1,3 +1,17 @@
-::ng-deep body {
+body {
   margin: 0;
+}
+
+.cv-layout {
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+}
+
+.cv-layout-header {
+  width: 100%;
+}
+
+.cv-layout-container {
+  width: 100%;
 }

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.html
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.html
@@ -1,3 +1,17 @@
-<div class="cv-container">
-  <ng-content></ng-content>
+<div class="cv-layout">
+  <div class="cv-layout-header">
+    <ng-container
+      *ngTemplateOutlet="
+        headerTemplate || defaultHeader;
+        context: { $implicit: data.header }
+      "
+    ></ng-container>
+  </div>
+  <div class="cv-layout-container">
+    <ng-content></ng-content>
+  </div>
 </div>
+
+<ng-template cvHeader #defaultHeader let-header>
+  <h1>{{ header.title$ | async }}</h1>
+</ng-template>

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
@@ -1,21 +1,116 @@
+import { Component, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ChillVikingLayoutComponent } from '@chill-viking/layout';
+import { ChillVikingLayoutComponent, HeaderDirective, LayoutContext } from '@chill-viking/layout';
+import { of } from 'rxjs';
+
+const layoutContext: LayoutContext = {
+  header: {
+    title$: of('header.title'),
+  },
+};
+
+@Component({
+  template: `
+    <cv-layout [data]="ctx">
+      <ng-template cvHeader [context]="ctx.header" let-header>
+        <h2>overridden-template-header</h2>
+        <span class="data">{{ header | json }}</span>
+      </ng-template>
+    </cv-layout>
+  `,
+})
+class WithTemplateComponent {
+  ctx: LayoutContext = { ...layoutContext };
+}
+
+@Component({
+  template: `
+    <cv-layout [data]="ctx">
+      <p>hello world</p>
+    </cv-layout>
+    <span>Outside layout</span>
+  `,
+})
+class WithoutTemplateComponent {
+  ctx: LayoutContext = { ...layoutContext };
+}
+
+const actualDeclarations: Type<unknown>[] = [
+  ChillVikingLayoutComponent,
+  HeaderDirective,
+];
 
 describe('ChillVikingLayoutComponent', () => {
-  let component: ChillVikingLayoutComponent;
-  let fixture: ComponentFixture<ChillVikingLayoutComponent>;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ChillVikingLayoutComponent],
+      declarations: [
+        ...actualDeclarations,
+        WithTemplateComponent,
+        WithoutTemplateComponent,
+      ],
     }).compileComponents();
-
-    fixture = TestBed.createComponent(ChillVikingLayoutComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('component alone', () => {
+    let component: ChillVikingLayoutComponent;
+    let fixture: ComponentFixture<ChillVikingLayoutComponent>;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ChillVikingLayoutComponent);
+      component = fixture.componentInstance;
+      component.data = { ...layoutContext };
+      fixture.detectChanges();
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+  });
+
+  describe('used without templates', () => {
+    let fixture: ComponentFixture<WithoutTemplateComponent>;
+    let component: WithoutTemplateComponent;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WithoutTemplateComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should be created', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should default header displayed', () => {
+      const element = fixture.nativeElement;
+      expect(
+        element.querySelector('.cv-layout-header h1')?.textContent,
+      ).toContain('header.title');
+    });
+  });
+
+  describe('used with templates', () => {
+    let fixture: ComponentFixture<WithTemplateComponent>;
+    let component: WithTemplateComponent;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WithTemplateComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should be created', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should display header from template', () => {
+      const element = fixture.nativeElement;
+      expect(element.querySelector('.cv-layout-header h2').textContent).toEqual(
+        'overridden-template-header',
+      );
+      expect(
+        element.querySelector('.cv-layout-header .data').textContent,
+      ).toContain(`${JSON.stringify(layoutContext.header, null, 2)}`);
+    });
   });
 });

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.ts
@@ -1,8 +1,31 @@
-import { Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  Input,
+  TemplateRef,
+  ViewEncapsulation,
+} from '@angular/core';
+import { of } from 'rxjs';
+import { HeaderDirective } from '../directives/header.directive';
+import { LayoutContext } from '../models/layout-context';
+import { LayoutHeaderContext } from '../models/layout-header-context';
 
 @Component({
   selector: 'cv-layout',
   templateUrl: './chill-viking-layout.component.html',
   styleUrls: ['./chill-viking-layout.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
 })
-export class ChillVikingLayoutComponent {}
+export class ChillVikingLayoutComponent {
+  @Input()
+  data: LayoutContext = {
+    header: {
+      title$: of(`[data] not supplied`),
+    },
+  };
+
+  @ContentChild(HeaderDirective, { read: TemplateRef })
+  headerTemplate?: TemplateRef<LayoutHeaderContext>;
+}

--- a/libs/layout/src/lib/models.ts
+++ b/libs/layout/src/lib/models.ts
@@ -1,0 +1,2 @@
+export * from './models/as-implicit';
+export * from './models/layout-header-context';

--- a/libs/layout/src/lib/models.ts
+++ b/libs/layout/src/lib/models.ts
@@ -1,2 +1,3 @@
 export * from './models/as-implicit';
+export * from './models/layout-context';
 export * from './models/layout-header-context';

--- a/libs/layout/src/lib/models/as-implicit.ts
+++ b/libs/layout/src/lib/models/as-implicit.ts
@@ -1,0 +1,3 @@
+export type AsImplicit<TContext> = {
+  $implicit: TContext;
+};

--- a/libs/layout/src/lib/models/layout-context.ts
+++ b/libs/layout/src/lib/models/layout-context.ts
@@ -1,0 +1,5 @@
+import { LayoutHeaderContext } from './layout-header-context';
+
+export type LayoutContext = {
+  header: LayoutHeaderContext;
+};

--- a/libs/layout/src/lib/models/layout-header-context.ts
+++ b/libs/layout/src/lib/models/layout-header-context.ts
@@ -1,0 +1,5 @@
+import { Observable } from 'rxjs';
+
+export type LayoutHeaderContext = {
+  title$: Observable<string>;
+};


### PR DESCRIPTION
## Changes
Added `HeaderDirective` to be used as placeholder for a template to define a header in the resulting layout.

## Issues to adjust
Closes #21

Related #16

## Checklist
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

  Updated to allow users to define their own header for the layout.
