### PR TITLE
feat(@chill-viking/layout): add footer section

### DIFF
--- a/apps/chill-viking-ng-libs/src/app/app.component.html
+++ b/apps/chill-viking-ng-libs/src/app/app.component.html
@@ -3,4 +3,8 @@
     <h1>Welcome {{ header.title$ | async }}</h1>
   </ng-template>
   <p>content</p>
+  <ng-template cvFooter let-footer>
+    <h2>Footer content</h2>
+    <p class="copy">&copy; 2022 {{ footer.copyrightHolder }}</p>
+  </ng-template>
 </cv-layout>

--- a/apps/chill-viking-ng-libs/src/app/app.component.scss
+++ b/apps/chill-viking-ng-libs/src/app/app.component.scss
@@ -1,3 +1,8 @@
 h1 {
   font-weight: bold;
 }
+
+.copy {
+  background: pink;
+  color: purple;
+}

--- a/apps/chill-viking-ng-libs/src/app/app.component.ts
+++ b/apps/chill-viking-ng-libs/src/app/app.component.ts
@@ -13,5 +13,8 @@ export class AppComponent {
     header: {
       title$: of(this.title),
     },
+    footer: {
+      copyrightHolder: 'chill-viking',
+    },
   };
 }

--- a/libs/layout/src/lib/chill-viking-layout.module.ts
+++ b/libs/layout/src/lib/chill-viking-layout.module.ts
@@ -2,10 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { HeaderDirective } from './directives/header.directive';
 import { ChillVikingLayoutComponent } from './layout/chill-viking-layout.component';
+import { FooterDirective } from './directives/footer.directive';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [ChillVikingLayoutComponent, HeaderDirective],
-  exports: [ChillVikingLayoutComponent, HeaderDirective],
+  declarations: [ChillVikingLayoutComponent, HeaderDirective, FooterDirective],
+  exports: [ChillVikingLayoutComponent, HeaderDirective, FooterDirective],
 })
 export class ChillVikingLayoutModule {}

--- a/libs/layout/src/lib/chill-viking-layout.module.ts
+++ b/libs/layout/src/lib/chill-viking-layout.module.ts
@@ -1,8 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { HeaderDirective } from './directives/header.directive';
+import { FooterDirective, HeaderDirective } from './directives';
 import { ChillVikingLayoutComponent } from './layout/chill-viking-layout.component';
-import { FooterDirective } from './directives/footer.directive';
 
 @NgModule({
   imports: [CommonModule],

--- a/libs/layout/src/lib/directives.ts
+++ b/libs/layout/src/lib/directives.ts
@@ -1,1 +1,2 @@
+export * from './directives/footer.directive';
 export * from './directives/header.directive';

--- a/libs/layout/src/lib/directives/all-directives.spec.ts
+++ b/libs/layout/src/lib/directives/all-directives.spec.ts
@@ -1,0 +1,128 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  AsImplicit,
+  FooterDirective,
+  HeaderDirective,
+  LayoutContext,
+} from '@chill-viking/layout';
+import { of } from 'rxjs';
+
+type Immutable<T> = {
+  readonly [K in keyof T]: Immutable<Required<T[K]>>;
+};
+
+// each property set to required to force update when LayoutContext changes.
+const layoutContext: Immutable<LayoutContext> = {
+  header: {
+    title$: of('a title'),
+  },
+  footer: {
+    copyrightHolder: 'a person',
+  },
+};
+
+@Component({
+  selector: 'cv-layout-renderer',
+  template: `
+    <div id="header-block">
+      <ng-container
+        *ngTemplateOutlet="headerTemplate; context: getContext(ctx.header)"
+      ></ng-container>
+    </div>
+    <div id="footer-block">
+      <ng-container
+        *ngTemplateOutlet="footerTemplate; context: getContext(ctx.footer)"
+      ></ng-container>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class LayoutRendererComponent {
+  @ContentChild(FooterDirective, { read: FooterDirective })
+  footerTemplate!: FooterDirective;
+
+  @ContentChild(HeaderDirective, { read: HeaderDirective })
+  headerTemplate!: HeaderDirective;
+
+  ctx: LayoutContext = layoutContext as LayoutContext;
+
+  getContext<T>($implicit: T): AsImplicit<T> {
+    return { $implicit };
+  }
+}
+
+@Component({
+  template: `
+    <cv-layout-renderer>
+      <ng-template cvFooter let-footer>
+        <p>{{ footer.copyrightHolder }}</p>
+        <span class="json">{{ footer | json }}</span>
+      </ng-template>
+      <ng-template cvHeader let-header>
+        <p>{{ header.title$ | async }}</p>
+        <span class="json">{{ header | json }}</span>
+      </ng-template>
+    </cv-layout-renderer>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {}
+
+describe('Directives as Templates', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        FooterDirective,
+        HeaderDirective,
+        HostComponent,
+        LayoutRendererComponent,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    // if component can be created, then directives can be created.
+    expect(component).toBeTruthy();
+  });
+
+  const theoryForTemplate = <T>(
+    template: 'header' | 'footer',
+    expectedInnerHtml: string,
+    expectedJsonObject: T,
+  ) => {
+    describe(`${template}-template`, () => {
+      it('should render paragraph as expected', () => {
+        const element = fixture.nativeElement.querySelector(
+          `#${template}-block p`,
+        );
+        expect(element).toHaveProperty('innerHTML', expectedInnerHtml);
+      });
+
+      it('should render context as expected', () => {
+        const element = fixture.nativeElement.querySelector(
+          `#${template}-block span.json`,
+        );
+        expect(element).toHaveProperty(
+          'innerHTML',
+          JSON.stringify(expectedJsonObject, null, 2),
+        );
+      });
+    });
+  };
+
+  theoryForTemplate('footer', `a person`, layoutContext.footer);
+
+  theoryForTemplate('header', `a title`, layoutContext.header);
+});

--- a/libs/layout/src/lib/directives/footer.directive.spec.ts
+++ b/libs/layout/src/lib/directives/footer.directive.spec.ts
@@ -1,70 +1,33 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  ContentChild,
-  TemplateRef,
-} from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { LayoutFooterContext } from '@chill-viking/layout';
+import { Injector } from '@angular/core';
+import { FooterDirectiveTemplateContext } from '@chill-viking/layout';
+import { MockService } from 'ng-mocks';
 import { FooterDirective } from './footer.directive';
 
-@Component({
-  selector: 'cv-layout-footer-renderer',
-  template: `
-    <div id="template-render-block">
-      <ng-container
-        [ngTemplateOutlet]="template"
-        [ngTemplateOutletContext]="{ $implicit: ctx }"
-      ></ng-container>
-    </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class LayoutFooterRendererComponent {
-  @ContentChild(FooterDirective, { read: TemplateRef<LayoutFooterContext> })
-  template!: TemplateRef<LayoutFooterContext>;
-  ctx: LayoutFooterContext = {
-    copyrightHolder: 'a person',
-  };
-}
-
-@Component({
-  template: ` <cv-layout-footer-renderer>
-    <ng-template cvFooter let-footer>
-      <p>{{ footer.copyrightHolder }}</p>
-    </ng-template>
-  </cv-layout-footer-renderer>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class HostComponent {}
-
 describe('FooterDirective', () => {
-  let fixture: ComponentFixture<HostComponent>;
-  let component: HostComponent;
+  let mockedDirective: FooterDirective;
+  let context: FooterDirectiveTemplateContext;
+  let directive: FooterDirective;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        FooterDirective,
-        HostComponent,
-        LayoutFooterRendererComponent,
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(HostComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    mockedDirective = MockService(FooterDirective, {
+      createEmbeddedView: jest.fn(),
+    });
+    context = { $implicit: {} };
+    directive = new FooterDirective(mockedDirective);
   });
 
   it('should create', () => {
-    // if component can be created, then directive also created.
-    expect(component).toBeTruthy();
+    expect(directive).toBeTruthy();
   });
 
-  it('should be rendered correctly in component', () => {
-    const element = fixture.nativeElement;
-    expect(element.querySelector('#template-render-block').innerHTML).toContain(
-      '<p>a person</p>',
+  it('should use injected TemplateRef', () => {
+    const injector = MockService(Injector);
+
+    directive.createEmbeddedView(context, injector);
+
+    expect(mockedDirective.createEmbeddedView).toHaveBeenCalledWith(
+      context,
+      injector,
     );
   });
 });

--- a/libs/layout/src/lib/directives/footer.directive.spec.ts
+++ b/libs/layout/src/lib/directives/footer.directive.spec.ts
@@ -1,0 +1,70 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  TemplateRef,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LayoutFooterContext } from '@chill-viking/layout';
+import { FooterDirective } from './footer.directive';
+
+@Component({
+  selector: 'cv-layout-footer-renderer',
+  template: `
+    <div id="template-render-block">
+      <ng-container
+        [ngTemplateOutlet]="template"
+        [ngTemplateOutletContext]="{ $implicit: ctx }"
+      ></ng-container>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class LayoutFooterRendererComponent {
+  @ContentChild(FooterDirective, { read: TemplateRef<LayoutFooterContext> })
+  template!: TemplateRef<LayoutFooterContext>;
+  ctx: LayoutFooterContext = {
+    copyrightHolder: 'a person',
+  };
+}
+
+@Component({
+  template: ` <cv-layout-footer-renderer>
+    <ng-template cvFooter let-footer>
+      <p>{{ footer.copyrightHolder }}</p>
+    </ng-template>
+  </cv-layout-footer-renderer>`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {}
+
+describe('FooterDirective', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        FooterDirective,
+        HostComponent,
+        LayoutFooterRendererComponent,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    // if component can be created, then directive also created.
+    expect(component).toBeTruthy();
+  });
+
+  it('should be rendered correctly in component', () => {
+    const element = fixture.nativeElement;
+    expect(element.querySelector('#template-render-block').innerHTML).toContain(
+      '<p>a person</p>',
+    );
+  });
+});

--- a/libs/layout/src/lib/directives/footer.directive.ts
+++ b/libs/layout/src/lib/directives/footer.directive.ts
@@ -1,0 +1,33 @@
+import {
+  Directive,
+  ElementRef,
+  EmbeddedViewRef,
+  Injector,
+  TemplateRef,
+} from '@angular/core';
+import {
+  AsImplicit,
+  HeaderDirectiveTemplateContext,
+  LayoutFooterContext,
+} from '@chill-viking/layout';
+
+export type FooterDirectiveTemplateContext = AsImplicit<LayoutFooterContext>;
+
+@Directive({
+  selector: 'ng-template[cvFooter]',
+})
+export class FooterDirective extends TemplateRef<FooterDirectiveTemplateContext> {
+  constructor(
+    private _templateRef: TemplateRef<FooterDirectiveTemplateContext>,
+    public readonly elementRef: ElementRef,
+  ) {
+    super();
+  }
+
+  createEmbeddedView(
+    context: FooterDirectiveTemplateContext,
+    injector: Injector | undefined,
+  ): EmbeddedViewRef<FooterDirectiveTemplateContext> {
+    return this._templateRef.createEmbeddedView(context, injector);
+  }
+}

--- a/libs/layout/src/lib/directives/footer.directive.ts
+++ b/libs/layout/src/lib/directives/footer.directive.ts
@@ -1,15 +1,5 @@
-import {
-  Directive,
-  ElementRef,
-  EmbeddedViewRef,
-  Injector,
-  TemplateRef,
-} from '@angular/core';
-import {
-  AsImplicit,
-  HeaderDirectiveTemplateContext,
-  LayoutFooterContext,
-} from '@chill-viking/layout';
+import { Directive, EmbeddedViewRef, Injector, TemplateRef } from '@angular/core';
+import { AsImplicit, LayoutFooterContext } from '@chill-viking/layout';
 
 export type FooterDirectiveTemplateContext = AsImplicit<LayoutFooterContext>;
 
@@ -17,9 +7,10 @@ export type FooterDirectiveTemplateContext = AsImplicit<LayoutFooterContext>;
   selector: 'ng-template[cvFooter]',
 })
 export class FooterDirective extends TemplateRef<FooterDirectiveTemplateContext> {
+  readonly elementRef = this._templateRef.elementRef;
+
   constructor(
     private _templateRef: TemplateRef<FooterDirectiveTemplateContext>,
-    public readonly elementRef: ElementRef,
   ) {
     super();
   }

--- a/libs/layout/src/lib/directives/footer.directive.ts
+++ b/libs/layout/src/lib/directives/footer.directive.ts
@@ -1,5 +1,10 @@
-import { Directive, EmbeddedViewRef, Injector, TemplateRef } from '@angular/core';
-import { AsImplicit, LayoutFooterContext } from '@chill-viking/layout';
+import {
+  Directive,
+  EmbeddedViewRef,
+  Injector,
+  TemplateRef,
+} from '@angular/core';
+import { AsImplicit, LayoutFooterContext } from '../models';
 
 export type FooterDirectiveTemplateContext = AsImplicit<LayoutFooterContext>;
 

--- a/libs/layout/src/lib/directives/header.directive.spec.ts
+++ b/libs/layout/src/lib/directives/header.directive.spec.ts
@@ -1,66 +1,32 @@
-import { ChangeDetectionStrategy, Component, ContentChild, TemplateRef } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { LayoutHeaderContext } from '@chill-viking/layout';
-import { of } from 'rxjs';
+import { Injector } from '@angular/core';
+import { HeaderDirectiveTemplateContext } from '@chill-viking/layout';
+import { MockService } from 'ng-mocks';
 import { HeaderDirective } from './header.directive';
 
-@Component({
-  selector: 'cv-layout-header-renderer',
-  template: `
-    <div id="template-render-block">
-      <ng-container
-        [ngTemplateOutlet]="template"
-        [ngTemplateOutletContext]="{ $implicit: ctx }"
-      ></ng-container>
-    </div>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class LayoutHeaderRendererComponent {
-  @ContentChild(HeaderDirective, { read: TemplateRef<LayoutHeaderContext> })
-  template!: TemplateRef<LayoutHeaderContext>;
-  ctx: LayoutHeaderContext = {
-    title$: of('hello'),
-  };
-}
-
-@Component({
-  template: ` <cv-layout-header-renderer>
-    <ng-template cvHeader let-header>
-      <p>{{ header.title$ | async }}</p>
-    </ng-template>
-  </cv-layout-header-renderer>`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class HostComponent {}
-
 describe('HeaderDirective', () => {
-  let fixture: ComponentFixture<HostComponent>;
-  let component: HostComponent;
+  let mockedDirective: HeaderDirective;
+  let context: HeaderDirectiveTemplateContext;
+  let directive: HeaderDirective;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [
-        HeaderDirective,
-        HostComponent,
-        LayoutHeaderRendererComponent,
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(HostComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    mockedDirective = MockService(HeaderDirective, {
+      createEmbeddedView: jest.fn(),
+    });
+    directive = new HeaderDirective(mockedDirective);
   });
 
   it('should create', () => {
-    // if component can be created, then directive also created.
-    expect(component).toBeTruthy();
+    expect(directive).toBeTruthy();
   });
 
-  it('should be rendered correctly in component', () => {
-    const element = fixture.nativeElement;
-    expect(element.querySelector('#template-render-block').innerHTML).toContain(
-      '<p>hello</p>',
+  it('should use injected TemplateRef', () => {
+    const injector = MockService(Injector);
+
+    directive.createEmbeddedView(context, injector);
+
+    expect(mockedDirective.createEmbeddedView).toHaveBeenCalledWith(
+      context,
+      injector,
     );
   });
 });

--- a/libs/layout/src/lib/directives/header.directive.ts
+++ b/libs/layout/src/lib/directives/header.directive.ts
@@ -1,4 +1,10 @@
-import { Directive, ElementRef, EmbeddedViewRef, Injector, TemplateRef } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  EmbeddedViewRef,
+  Injector,
+  TemplateRef,
+} from '@angular/core';
 import { AsImplicit } from '../models/as-implicit';
 import { LayoutHeaderContext } from '../models/layout-header-context';
 
@@ -8,18 +14,12 @@ export type HeaderDirectiveTemplateContext = AsImplicit<LayoutHeaderContext>;
   selector: 'ng-template[cvHeader]',
 })
 export class HeaderDirective extends TemplateRef<HeaderDirectiveTemplateContext> {
+  readonly elementRef = this._templateRef.elementRef;
+
   constructor(
     private _templateRef: TemplateRef<HeaderDirectiveTemplateContext>,
-    public readonly elementRef: ElementRef,
   ) {
     super();
-  }
-
-  static ngTemplateContextGuard(
-    template: TemplateRef<HeaderDirectiveTemplateContext>,
-    context: unknown,
-  ): context is HeaderDirectiveTemplateContext {
-    return true;
   }
 
   createEmbeddedView(

--- a/libs/layout/src/lib/directives/header.directive.ts
+++ b/libs/layout/src/lib/directives/header.directive.ts
@@ -1,6 +1,5 @@
 import {
   Directive,
-  ElementRef,
   EmbeddedViewRef,
   Injector,
   TemplateRef,

--- a/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
@@ -10,6 +10,10 @@ import { of } from 'rxjs';
         <h2>overridden-template-header</h2>
         <span class="json">{{ header | json }}</span>
       </ng-template>
+      <ng-template cvFooter let-footer>
+        <p>{{ footer.copyrightHolder }}</p>
+        <span class="json">{{ footer | json }}</span>
+      </ng-template>
     </cv-layout>
   `,
 })
@@ -35,6 +39,9 @@ describe('ChillVikingLayoutComponent with Templates', () => {
     layoutContext = {
       header: {
         title$: of('header.title'),
+      },
+      footer: {
+        copyrightHolder: 'a dude',
       },
     };
     component.ctx = layoutContext;
@@ -64,5 +71,13 @@ describe('ChillVikingLayoutComponent with Templates', () => {
       'overridden-template-header',
     );
     expectJsonRendered(element, layoutContext.header);
+  });
+
+  it('should display footer from template', () => {
+    const element = fixture.nativeElement.querySelector('.cv-layout-footer');
+
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element.querySelector('p')?.textContent).toContain('a dude');
+    expectJsonRendered(element, layoutContext.footer);
   });
 });

--- a/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChillVikingLayoutModule, LayoutContext } from '@chill-viking/layout';
+import { of } from 'rxjs';
+
+@Component({
+  template: `
+    <cv-layout [data]="ctx">
+      <ng-template cvHeader let-header>
+        <h2>overridden-template-header</h2>
+        <span class="json">{{ header | json }}</span>
+      </ng-template>
+    </cv-layout>
+  `,
+})
+class HostComponent {
+  ctx!: LayoutContext;
+}
+
+describe('ChillVikingLayoutComponent with Templates', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+  let layoutContext: LayoutContext;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChillVikingLayoutModule],
+      declarations: [HostComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.componentInstance;
+    layoutContext = {
+      header: {
+        title$: of('header.title'),
+      },
+    };
+    component.ctx = layoutContext;
+
+    fixture.detectChanges();
+  });
+
+  const expectJsonRendered = <T>(
+    templateElement: HTMLDivElement,
+    expectedValue: T,
+  ): void => {
+    const expectedContent = JSON.stringify(expectedValue, null, 2);
+    const jsonContainer = templateElement.querySelector('.json');
+
+    expect(jsonContainer?.textContent).toContain(expectedContent);
+  };
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display header from template', () => {
+    const element = fixture.nativeElement.querySelector('.cv-layout-header');
+
+    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element.querySelector('h2')?.textContent).toEqual(
+      'overridden-template-header',
+    );
+    expectJsonRendered(element, layoutContext.header);
+  });
+});

--- a/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout-with-templates.component.spec.ts
@@ -66,7 +66,7 @@ describe('ChillVikingLayoutComponent with Templates', () => {
   it('should display header from template', () => {
     const element = fixture.nativeElement.querySelector('.cv-layout-header');
 
-    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element).toBeInstanceOf(HTMLElement);
     expect(element.querySelector('h2')?.textContent).toEqual(
       'overridden-template-header',
     );
@@ -76,7 +76,7 @@ describe('ChillVikingLayoutComponent with Templates', () => {
   it('should display footer from template', () => {
     const element = fixture.nativeElement.querySelector('.cv-layout-footer');
 
-    expect(element).toBeInstanceOf(HTMLDivElement);
+    expect(element).toBeInstanceOf(HTMLElement);
     expect(element.querySelector('p')?.textContent).toContain('a dude');
     expectJsonRendered(element, layoutContext.footer);
   });

--- a/libs/layout/src/lib/layout/chill-viking-layout-without-templates.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout-without-templates.component.spec.ts
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ChillVikingLayoutModule, LayoutContext } from '@chill-viking/layout';
+import { BehaviorSubject } from 'rxjs';
+
+@Component({
+  template: `
+    <cv-layout [data]="ctx">
+      <p>hello world</p>
+    </cv-layout>
+    <span>Outside layout</span>
+  `,
+})
+class HostComponent {
+  ctx!: LayoutContext;
+}
+
+describe('ChillVikingLayoutComponent without Templates', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let component: HostComponent;
+  let titleSubject: BehaviorSubject<string>;
+  let layoutContext: LayoutContext;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ChillVikingLayoutModule],
+      declarations: [HostComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostComponent);
+    component = fixture.componentInstance;
+    titleSubject = new BehaviorSubject<string>('header.title');
+    const title$ = titleSubject.asObservable();
+    layoutContext = {
+      header: { title$ },
+    };
+    component.ctx = layoutContext;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should default header displayed', () => {
+    const element = fixture.nativeElement;
+    expect(
+      element.querySelector('.cv-layout-header h1')?.textContent,
+    ).toContain('header.title');
+  });
+});

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.html
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.html
@@ -1,20 +1,20 @@
 <div class="cv-layout">
-  <div class="cv-layout-header">
+  <header class="cv-layout-header">
     <ng-container
       *ngTemplateOutlet="
         headerTemplate || defaultHeader;
         context: getContext(data.header)
       "
     ></ng-container>
-  </div>
+  </header>
   <div class="cv-layout-container">
     <ng-content></ng-content>
   </div>
-  <div *ngIf="footerTemplate" class="cv-layout-footer">
+  <footer *ngIf="footerTemplate" class="cv-layout-footer">
     <ng-container
       *ngTemplateOutlet="footerTemplate; context: getContext(data.footer)"
     ></ng-container>
-  </div>
+  </footer>
 </div>
 
 <ng-template cvHeader #defaultHeader let-header>

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.html
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.html
@@ -3,12 +3,17 @@
     <ng-container
       *ngTemplateOutlet="
         headerTemplate || defaultHeader;
-        context: { $implicit: data.header }
+        context: getContext(data.header)
       "
     ></ng-container>
   </div>
   <div class="cv-layout-container">
     <ng-content></ng-content>
+  </div>
+  <div *ngIf="footerTemplate" class="cv-layout-footer">
+    <ng-container
+      *ngTemplateOutlet="footerTemplate; context: getContext(data.footer)"
+    ></ng-container>
   </div>
 </div>
 

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
@@ -1,5 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ChillVikingLayoutComponent } from '@chill-viking/layout';
+import {
+  ChillVikingLayoutComponent,
+  FooterDirective,
+} from '@chill-viking/layout';
+import { MockInstance, MockService } from 'ng-mocks';
 import { first } from 'rxjs';
 
 describe('ChillVikingLayoutComponent', () => {
@@ -28,6 +32,51 @@ describe('ChillVikingLayoutComponent', () => {
     component.data.header.title$.pipe(first()).subscribe((defaultTitle) => {
       expect(defaultTitle).toContain('[data] not supplied');
       done();
+    });
+  });
+
+  describe('getContext', () => {
+    it('should created expected context', () => {
+      const actual = component.getContext({ value: 'hello' });
+      expect(actual).toEqual({ $implicit: { value: 'hello' } });
+    });
+  });
+
+  describe('get showFooter', () => {
+    const checkShowFooter = (combinedResult: boolean) => {
+      describe('and [data.footer] is undefined', () => {
+        it('should return false', () => {
+          expect(component.data.footer).toBeUndefined();
+          // fixture.detectChanges();
+          expect(component.showFooter).toBeFalsy();
+        });
+      });
+
+      describe('and [data.footer] is defined', () => {
+        it(`should return ${combinedResult}`, () => {
+          component.data.footer = {
+            copyrightHolder: 'hello',
+          };
+          // fixture.detectChanges();
+          expect(component.showFooter).toEqual(combinedResult);
+        });
+      });
+    };
+
+    describe('when footerTemplate is defined', () => {
+      beforeEach(() => {
+        component.footerTemplate = MockService(FooterDirective);
+      });
+
+      checkShowFooter(true);
+    });
+
+    describe('when footerTemplate is undefined', () => {
+      beforeEach(() => {
+        component.footerTemplate = undefined;
+      });
+
+      checkShowFooter(false);
     });
   });
 });

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.spec.ts
@@ -1,116 +1,33 @@
-import { Component, Type } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ChillVikingLayoutComponent, HeaderDirective, LayoutContext } from '@chill-viking/layout';
-import { of } from 'rxjs';
-
-const layoutContext: LayoutContext = {
-  header: {
-    title$: of('header.title'),
-  },
-};
-
-@Component({
-  template: `
-    <cv-layout [data]="ctx">
-      <ng-template cvHeader [context]="ctx.header" let-header>
-        <h2>overridden-template-header</h2>
-        <span class="data">{{ header | json }}</span>
-      </ng-template>
-    </cv-layout>
-  `,
-})
-class WithTemplateComponent {
-  ctx: LayoutContext = { ...layoutContext };
-}
-
-@Component({
-  template: `
-    <cv-layout [data]="ctx">
-      <p>hello world</p>
-    </cv-layout>
-    <span>Outside layout</span>
-  `,
-})
-class WithoutTemplateComponent {
-  ctx: LayoutContext = { ...layoutContext };
-}
-
-const actualDeclarations: Type<unknown>[] = [
-  ChillVikingLayoutComponent,
-  HeaderDirective,
-];
+import { ChillVikingLayoutComponent } from '@chill-viking/layout';
+import { first } from 'rxjs';
 
 describe('ChillVikingLayoutComponent', () => {
+  let component: ChillVikingLayoutComponent;
+  let fixture: ComponentFixture<ChillVikingLayoutComponent>;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        ...actualDeclarations,
-        WithTemplateComponent,
-        WithoutTemplateComponent,
-      ],
+      declarations: [ChillVikingLayoutComponent],
     }).compileComponents();
   });
 
-  describe('component alone', () => {
-    let component: ChillVikingLayoutComponent;
-    let fixture: ComponentFixture<ChillVikingLayoutComponent>;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(ChillVikingLayoutComponent);
-      component = fixture.componentInstance;
-      component.data = { ...layoutContext };
-      fixture.detectChanges();
-    });
-
-    it('should create', () => {
-      expect(component).toBeTruthy();
-    });
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChillVikingLayoutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
-  describe('used without templates', () => {
-    let fixture: ComponentFixture<WithoutTemplateComponent>;
-    let component: WithoutTemplateComponent;
-
-    beforeEach(() => {
-      fixture = TestBed.createComponent(WithoutTemplateComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    });
-
-    it('should be created', () => {
-      expect(component).toBeTruthy();
-    });
-
-    it('should default header displayed', () => {
-      const element = fixture.nativeElement;
-      expect(
-        element.querySelector('.cv-layout-header h1')?.textContent,
-      ).toContain('header.title');
-    });
+  it('should create', () => {
+    expect(component).toBeTruthy();
   });
 
-  describe('used with templates', () => {
-    let fixture: ComponentFixture<WithTemplateComponent>;
-    let component: WithTemplateComponent;
+  it('should default [data]', (done) => {
+    expect(component.data.header).toBeTruthy();
 
-    beforeEach(() => {
-      fixture = TestBed.createComponent(WithTemplateComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-    });
-
-    it('should be created', () => {
-      expect(component).toBeTruthy();
-    });
-
-    it('should display header from template', () => {
-      const element = fixture.nativeElement;
-      expect(element.querySelector('.cv-layout-header h2').textContent).toEqual(
-        'overridden-template-header',
-      );
-      expect(
-        element.querySelector('.cv-layout-header .data').textContent,
-      ).toContain(`${JSON.stringify(layoutContext.header, null, 2)}`);
+    component.data.header.title$.pipe(first()).subscribe((defaultTitle) => {
+      expect(defaultTitle).toContain('[data] not supplied');
+      done();
     });
   });
 });

--- a/libs/layout/src/lib/layout/chill-viking-layout.component.ts
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.ts
@@ -3,13 +3,12 @@ import {
   Component,
   ContentChild,
   Input,
-  TemplateRef,
   ViewEncapsulation,
 } from '@angular/core';
 import { of } from 'rxjs';
-import { HeaderDirective } from '../directives/header.directive';
+import { FooterDirective, HeaderDirective } from '../directives';
+import { AsImplicit } from '../models/as-implicit';
 import { LayoutContext } from '../models/layout-context';
-import { LayoutHeaderContext } from '../models/layout-header-context';
 
 @Component({
   selector: 'cv-layout',
@@ -26,6 +25,17 @@ export class ChillVikingLayoutComponent {
     },
   };
 
-  @ContentChild(HeaderDirective, { read: TemplateRef })
-  headerTemplate?: TemplateRef<LayoutHeaderContext>;
+  @ContentChild(HeaderDirective, { read: HeaderDirective })
+  headerTemplate?: HeaderDirective;
+
+  @ContentChild(FooterDirective, { read: FooterDirective })
+  footerTemplate?: FooterDirective;
+
+  get showFooter(): boolean {
+    return !!this.footerTemplate && !!this.data.footer;
+  }
+
+  getContext<T>($implicit: T): AsImplicit<T> {
+    return { $implicit };
+  }
 }

--- a/libs/layout/src/lib/models.ts
+++ b/libs/layout/src/lib/models.ts
@@ -1,3 +1,4 @@
 export * from './models/as-implicit';
 export * from './models/layout-context';
+export * from './models/layout-footer-context';
 export * from './models/layout-header-context';

--- a/libs/layout/src/lib/models/layout-context.ts
+++ b/libs/layout/src/lib/models/layout-context.ts
@@ -1,5 +1,7 @@
+import { LayoutFooterContext } from './layout-footer-context';
 import { LayoutHeaderContext } from './layout-header-context';
 
 export type LayoutContext = {
   header: LayoutHeaderContext;
+  footer?: LayoutFooterContext;
 };

--- a/libs/layout/src/lib/models/layout-footer-context.ts
+++ b/libs/layout/src/lib/models/layout-footer-context.ts
@@ -1,0 +1,3 @@
+export type LayoutFooterContext = {
+  copyrightHolder?: string;
+};


### PR DESCRIPTION
## Changes

Created `cvFooter` directive to use in layout content to be consumed as template to project into footer of layout.

## Additional changes
- Improved specs to have individual files for specific contexts
- Updated `cvHeader` directive to be projected into `<header>` element

## Related issues

Closes #35 
Related to #16 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, make sure that [Changes](#changes) has a brief summary of change.
