### PR TITLE
fix(@chill-viking/layout): force layout container width

### DIFF
--- a/libs/layout/src/lib/layout/chill-viking-layout.component.css
+++ b/libs/layout/src/lib/layout/chill-viking-layout.component.css
@@ -5,13 +5,18 @@ body {
 .cv-layout {
   display: flex;
   flex-direction: column;
-  width: 100vw;
+  width: auto;
+  box-sizing: border-box;
 }
 
 .cv-layout-header {
-  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .cv-layout-container {
-  width: 100%;
+  width: auto;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow-x: auto;
 }


### PR DESCRIPTION
## 🎉 Description

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Update `@chill-viking/layout` to only use available width

Fixes #42 

## 🚀 Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration 
-->

- [x] 3 tier layout - created 3 nested layouts with filler blocks, made last filler block extend beyond its available width and did not make browser page wider than its actual width.

![image](https://user-images.githubusercontent.com/7055026/210199785-c80083f0-a534-4b2c-b7af-e6ce0622dd31.png)

> Example screenshot taken before extending last filler block, but confirmed that scroll bar shown for container when width &gt; container.

## 🧾 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
