### PR TITLE
chore(workflows): set basic permissions for workflows

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
@@ -1,3 +1,12 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+
 name: publish-ng-libs-site
 
 on:

--- a/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
@@ -9,14 +9,8 @@ on:
 
 name: publish-ng-libs-site
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
+permissions:
+  contents: read
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/chill-viking-ng-libs-sonar-cloud.yml
+++ b/.github/workflows/chill-viking-ng-libs-sonar-cloud.yml
@@ -1,10 +1,11 @@
-name: chill-viking-ng-libs-sonar-cloud
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
+
+name: chill-viking-ng-libs-sonar-cloud
 
 env:
   SONAR_TOKEN: ${{ secrets.DEMO_APP_SONAR_TOKEN }}

--- a/.github/workflows/chill-viking-ng-libs-sonar-cloud.yml
+++ b/.github/workflows/chill-viking-ng-libs-sonar-cloud.yml
@@ -7,6 +7,9 @@ on:
 
 name: chill-viking-ng-libs-sonar-cloud
 
+permissions:
+  contents: read
+
 env:
   SONAR_TOKEN: ${{ secrets.DEMO_APP_SONAR_TOKEN }}
   COVERAGE_LOCATION: 'coverage/lcov.info'

--- a/.github/workflows/chill-viking-stale.yml
+++ b/.github/workflows/chill-viking-stale.yml
@@ -1,3 +1,7 @@
+on:
+  schedule:
+    - cron: '37 20 * * *'
+
 # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
 #
 # You can adjust the behavior by modifying this file.

--- a/.github/workflows/chill-viking-stale.yml
+++ b/.github/workflows/chill-viking-stale.yml
@@ -9,23 +9,21 @@ on:
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
-on:
-  schedule:
-  - cron: '37 20 * * *'
+permissions:
+  contents: read
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v7
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has grown stale due to inactivity. Remove `no-issue-activity` label or comment, or this will be closed in 7 days.'
-        stale-pr-message: 'This pull request has grown stale due to inactivity. Remove `no-pr-activity` label or comment, or this will be closed in 7 days.'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+      - uses: actions/stale@v7
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue has grown stale due to inactivity. Remove `no-issue-activity` label or comment, or this will be closed in 7 days.'
+          stale-pr-message: 'This pull request has grown stale due to inactivity. Remove `no-pr-activity` label or comment, or this will be closed in 7 days.'
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/layout-lib-sonar-cloud.yml
+++ b/.github/workflows/layout-lib-sonar-cloud.yml
@@ -11,6 +11,9 @@ on:
 
 name: layout-lib-sonar-cloud
 
+permissions:
+  contents: read
+
 env:
   SONAR_TOKEN: ${{ secrets.LAYOUT_LIB_SONAR_TOKEN }}
   COVERAGE_LOCATION: 'coverage/lcov.info'

--- a/.github/workflows/layout-lib-sonar-cloud.yml
+++ b/.github/workflows/layout-lib-sonar-cloud.yml
@@ -1,4 +1,3 @@
-name: layout-lib-sonar-cloud
 on:
   push:
     branches: [main]
@@ -9,6 +8,8 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - libs/layout/**
+
+name: layout-lib-sonar-cloud
 
 env:
   SONAR_TOKEN: ${{ secrets.LAYOUT_LIB_SONAR_TOKEN }}

--- a/.github/workflows/npm-publish-layout-alpha.yml
+++ b/.github/workflows/npm-publish-layout-alpha.yml
@@ -1,10 +1,11 @@
-name: npm-publish-layout-alpha
 on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
     paths:
       - libs/layout/**
+
+name: npm-publish-layout-alpha
 
 permissions: read-all
 

--- a/.github/workflows/nx-cloud-affected-ci.yml
+++ b/.github/workflows/nx-cloud-affected-ci.yml
@@ -1,11 +1,11 @@
-name: nx-cloud-affected-ci
-
 on:
   push:
     branches: ['main']
   pull_request:
     branches: ['main']
     types: [opened, synchronize, reopened]
+
+name: nx-cloud-affected-ci
 
 permissions: read-all
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,10 @@ on:
     branches: ['main']
 
 name: release-please
+
+permissions:
+  contents: read
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,8 +1,3 @@
-# This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
-
-name: Scorecards supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -14,6 +9,11 @@ on:
   push:
     branches: ['main']
 
+# This workflow uses actions that are not certified by GitHub. They are provided
+# by a third-party and are governed by separate terms of service, privacy
+# policy, and support documentation.
+
+name: Scorecards supply-chain security
 # Declare default permissions as read only.
 permissions: read-all
 


### PR DESCRIPTION
## 🎉 Description

Standardized workflow ordering:
1. `on`
2. `name`
3. `permissions`
4. `env` if set
5. `jobs`

And set `permissions` to `contents: read` to try and resolve security advisory.

Fixes #51 

## 🚀 Type of change

- [x] 🧹 Chore (non-breaking and non-functional change)
