### PR TITLE
feat(demo-app): set title using TitleStrategy

### DIFF
--- a/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
+++ b/.github/workflows/azure-static-web-apps-ashy-flower-0950bd703.yml
@@ -11,6 +11,7 @@ name: publish-ng-libs-site
 
 permissions:
   contents: read
+  pull-requests: write # Needed to add comment to PR.
 
 jobs:
   build_and_deploy_job:

--- a/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.spec.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.spec.ts
@@ -1,0 +1,55 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { BrowserTestingModule } from '@angular/platform-browser/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { MockProvider } from 'ng-mocks';
+import { PageTitleStrategyService } from './page-title-strategy.service';
+
+describe('PageTitleStrategyService', () => {
+  let titleSpy: Title;
+  let service: PageTitleStrategyService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, BrowserTestingModule],
+      providers: [
+        PageTitleStrategyService,
+        MockProvider(Title, { setTitle: jest.fn() }),
+      ],
+    }).compileComponents();
+
+    titleSpy = TestBed.inject(Title);
+    service = TestBed.inject(PageTitleStrategyService);
+  });
+
+  it('is created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  const createActivatedSnapshot = (
+    val: Partial<ActivatedRouteSnapshot>,
+  ): ActivatedRouteSnapshot => val as ActivatedRouteSnapshot;
+  const createRouterStateSnapshot = (
+    val: Partial<RouterStateSnapshot>,
+  ): RouterStateSnapshot => val as RouterStateSnapshot;
+
+  it('sets correct title', async () => {
+    const snapshot = createRouterStateSnapshot({
+      root: createActivatedSnapshot({
+        firstChild: createActivatedSnapshot({
+          title: 'First',
+          firstChild: createActivatedSnapshot({
+            title: 'Second',
+            firstChild: createActivatedSnapshot({ title: 'Third' }),
+          }),
+        }),
+      }),
+    });
+
+    service.updateTitle(snapshot);
+    expect(titleSpy.setTitle).toHaveBeenCalledWith(
+      'Third | Second | First | Chill Viking',
+    );
+  });
+});

--- a/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
@@ -27,8 +27,15 @@ export class PageTitleStrategyService extends TitleStrategy {
     return [activatedRootSnapshot.title ?? ''];
   }
 
+  private makeCurrentTitleFirst(...arr: string[]): string[] {
+    return [...arr].reverse();
+  }
+
   override updateTitle(snapshot: RouterStateSnapshot): void {
-    const titles = ['Chill Viking', ...this.resolveChildTitles(snapshot.root)];
-    this._title.setTitle(titles.reverse().join(' | '));
+    const titles = this.makeCurrentTitleFirst(
+      'Chill Viking',
+      ...this.resolveChildTitles(snapshot.root),
+    );
+    this._title.setTitle(titles.join(' | '));
   }
 }

--- a/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import {
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  TitleStrategy,
+} from '@angular/router';
+
+@Injectable()
+export class PageTitleStrategyService extends TitleStrategy {
+  constructor(private readonly _title: Title) {
+    super();
+  }
+
+  private resolveChildTitles(
+    activatedRootSnapshot: ActivatedRouteSnapshot,
+  ): string[] {
+    if (activatedRootSnapshot.firstChild) {
+      const result = [
+        activatedRootSnapshot.title ?? '',
+        ...this.resolveChildTitles(activatedRootSnapshot.firstChild),
+      ];
+
+      return result.filter((title) => title !== '');
+    }
+
+    return [activatedRootSnapshot.title ?? ''];
+  }
+
+  override updateTitle(snapshot: RouterStateSnapshot): void {
+    const titles = ['Chill Viking', ...this.resolveChildTitles(snapshot.root)];
+    this._title.setTitle(titles.reverse().join(' | '));
+  }
+}

--- a/apps/chill-viking-ng-libs/src/app/routes.ts
+++ b/apps/chill-viking-ng-libs/src/app/routes.ts
@@ -3,6 +3,7 @@ import { RouterFeatures, Routes } from '@angular/router';
 export const rootRoutes: Routes = [
   {
     path: '',
+    title: 'Home',
     loadComponent: () =>
       import('./pages/home/home.component').then((c) => {
         // Have to use braces to work around prettier's approach of wrapping lines... ffs

--- a/apps/chill-viking-ng-libs/src/main.ts
+++ b/apps/chill-viking-ng-libs/src/main.ts
@@ -1,8 +1,12 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
+import { provideRouter, TitleStrategy } from '@angular/router';
+import { PageTitleStrategyService } from './app/page-title-strategy.service';
 import { RootComponent } from './app/root.component';
 import { rootRouterFeatures, rootRoutes } from './app/routes';
 
 bootstrapApplication(RootComponent, {
-  providers: [provideRouter(rootRoutes, ...rootRouterFeatures)],
+  providers: [
+    provideRouter(rootRoutes, ...rootRouterFeatures),
+    { provide: TitleStrategy, useClass: PageTitleStrategyService },
+  ],
 });


### PR DESCRIPTION
## 🎉 Description

Set document title using title attribute in routes. Will consume all titles in the tree of the current route, and reverse the titles so that current or nearest to current title is first, followed by the rest of the titles in order and ending with ` | Chill Viking`.

Fixes #45 

## 🚀 Type of change

- [x] 🆕 New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration 
-->

- [x] Created temporary route with children setting title property to confirm title set correctly
- [x] Viewed current page without temporary routes and title set to `Home | Chill Viking`
- [x] Confirmed title change in the published site from this PR
    ![image](https://user-images.githubusercontent.com/7055026/210730249-74261295-9bd8-475a-b831-17c184830cbc.png)


## 🧾 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
