### PR TITLE
feat(demo-app): update meta data for site

### DIFF
--- a/apps/chill-viking-ng-libs/src/app/page-meta-data.service.spec.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-meta-data.service.spec.ts
@@ -1,6 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { Title } from '@angular/platform-browser';
+import { Meta, MetaDefinition, Title } from '@angular/platform-browser';
 import { BrowserTestingModule } from '@angular/platform-browser/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { MockProvider } from 'ng-mocks';
@@ -8,6 +8,7 @@ import { PageMetaDataService } from './page-meta-data.service';
 
 describe('PageMetaDataService', () => {
   let titleSpy: Title;
+  let metaSpy: Meta;
   let service: PageMetaDataService;
 
   beforeEach(async () => {
@@ -16,10 +17,12 @@ describe('PageMetaDataService', () => {
       providers: [
         PageMetaDataService,
         MockProvider(Title, { setTitle: jest.fn() }),
+        MockProvider(Meta, { updateTag: jest.fn() }),
       ],
     }).compileComponents();
 
     titleSpy = TestBed.inject(Title);
+    metaSpy = TestBed.inject(Meta);
     service = TestBed.inject(PageMetaDataService);
   });
 
@@ -30,26 +33,85 @@ describe('PageMetaDataService', () => {
   const createActivatedSnapshot = (
     val: Partial<ActivatedRouteSnapshot>,
   ): ActivatedRouteSnapshot => val as ActivatedRouteSnapshot;
+
   const createRouterStateSnapshot = (
     val: Partial<RouterStateSnapshot>,
   ): RouterStateSnapshot => val as RouterStateSnapshot;
 
-  it('sets correct title', async () => {
-    const snapshot = createRouterStateSnapshot({
-      root: createActivatedSnapshot({
-        firstChild: createActivatedSnapshot({
-          title: 'First',
+  describe('updateTitle', () => {
+    let snapshot: RouterStateSnapshot;
+    let updateMetaSpy: jest.SpiedFunction<(v: RouterStateSnapshot) => void>;
+
+    beforeEach(() => {
+      snapshot = createRouterStateSnapshot({
+        root: createActivatedSnapshot({
           firstChild: createActivatedSnapshot({
-            title: 'Second',
-            firstChild: createActivatedSnapshot({ title: 'Third' }),
+            title: 'First',
+            firstChild: createActivatedSnapshot({
+              title: 'Second',
+              firstChild: createActivatedSnapshot({ title: 'Third' }),
+            }),
           }),
         }),
-      }),
+      });
+
+      updateMetaSpy = jest.spyOn(service, 'updateMeta');
     });
 
-    service.updateTitle(snapshot);
-    expect(titleSpy.setTitle).toHaveBeenCalledWith(
-      'Third | Second | First | Chill Viking | ng-libs',
-    );
+    it('should set correct title', async () => {
+      service.updateTitle(snapshot);
+      expect(titleSpy.setTitle).toHaveBeenCalledWith(
+        'Third | Second | First | Chill Viking | ng-libs',
+      );
+    });
+
+    it('should call updateMeta', () => {
+      service.updateTitle(snapshot);
+      expect(updateMetaSpy).toHaveBeenCalledWith(snapshot);
+    });
+  });
+
+  describe('updateMeta', () => {
+    let snapshot: RouterStateSnapshot;
+    let updateTagSpy: jest.SpiedFunction<
+      (tag: MetaDefinition, selector?: string) => HTMLMetaElement | null
+    >;
+
+    beforeEach(() => {
+      snapshot = createRouterStateSnapshot({
+        root: createActivatedSnapshot({
+          firstChild: createActivatedSnapshot({
+            title: 'First',
+            firstChild: createActivatedSnapshot({
+              title: 'Second',
+              data: { meta: { description: 'should be ignored' } },
+              firstChild: createActivatedSnapshot({
+                title: 'Third',
+                data: {
+                  meta: {
+                    description: 'Third description',
+                    other: 'other tag',
+                  },
+                },
+              }),
+            }),
+          }),
+        }),
+      });
+
+      updateTagSpy = jest.spyOn(metaSpy, 'updateTag');
+    });
+
+    it('should use meta from current activated route data', async () => {
+      service.updateMeta(snapshot);
+      expect(updateTagSpy).toHaveBeenCalledWith({
+        name: 'description',
+        content: 'Third description',
+      });
+      expect(updateTagSpy).toHaveBeenCalledWith({
+        name: 'other',
+        content: 'other tag',
+      });
+    });
   });
 });

--- a/apps/chill-viking-ng-libs/src/app/page-meta-data.service.spec.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-meta-data.service.spec.ts
@@ -4,23 +4,23 @@ import { Title } from '@angular/platform-browser';
 import { BrowserTestingModule } from '@angular/platform-browser/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { MockProvider } from 'ng-mocks';
-import { PageTitleStrategyService } from './page-title-strategy.service';
+import { PageMetaDataService } from './page-meta-data.service';
 
-describe('PageTitleStrategyService', () => {
+describe('PageMetaDataService', () => {
   let titleSpy: Title;
-  let service: PageTitleStrategyService;
+  let service: PageMetaDataService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, BrowserTestingModule],
       providers: [
-        PageTitleStrategyService,
+        PageMetaDataService,
         MockProvider(Title, { setTitle: jest.fn() }),
       ],
     }).compileComponents();
 
     titleSpy = TestBed.inject(Title);
-    service = TestBed.inject(PageTitleStrategyService);
+    service = TestBed.inject(PageMetaDataService);
   });
 
   it('is created', () => {

--- a/apps/chill-viking-ng-libs/src/app/page-meta-data.service.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-meta-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Title } from '@angular/platform-browser';
+import { Meta, Title } from '@angular/platform-browser';
 import {
   ActivatedRouteSnapshot,
   RouterStateSnapshot,
@@ -8,7 +8,7 @@ import {
 
 @Injectable()
 export class PageMetaDataService extends TitleStrategy {
-  constructor(private readonly _title: Title) {
+  constructor(private readonly _title: Title, private readonly _meta: Meta) {
     super();
   }
 
@@ -31,11 +31,17 @@ export class PageMetaDataService extends TitleStrategy {
     return [...arr].reverse();
   }
 
+  updateMeta(snapshot: RouterStateSnapshot): void {
+    // to be implemented.
+  }
+
   override updateTitle(snapshot: RouterStateSnapshot): void {
     const titles = this.makeCurrentTitleFirst(
       'Chill Viking | ng-libs',
       ...this.resolveChildTitles(snapshot.root),
     );
     this._title.setTitle(titles.join(' | '));
+
+    this.updateMeta(snapshot);
   }
 }

--- a/apps/chill-viking-ng-libs/src/app/page-meta-data.service.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-meta-data.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/router';
 
 @Injectable()
-export class PageTitleStrategyService extends TitleStrategy {
+export class PageMetaDataService extends TitleStrategy {
   constructor(private readonly _title: Title) {
     super();
   }

--- a/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.spec.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.spec.ts
@@ -49,7 +49,7 @@ describe('PageTitleStrategyService', () => {
 
     service.updateTitle(snapshot);
     expect(titleSpy.setTitle).toHaveBeenCalledWith(
-      'Third | Second | First | Chill Viking',
+      'Third | Second | First | Chill Viking | ng-libs',
     );
   });
 });

--- a/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
+++ b/apps/chill-viking-ng-libs/src/app/page-title-strategy.service.ts
@@ -33,7 +33,7 @@ export class PageTitleStrategyService extends TitleStrategy {
 
   override updateTitle(snapshot: RouterStateSnapshot): void {
     const titles = this.makeCurrentTitleFirst(
-      'Chill Viking',
+      'Chill Viking | ng-libs',
       ...this.resolveChildTitles(snapshot.root),
     );
     this._title.setTitle(titles.join(' | '));

--- a/apps/chill-viking-ng-libs/src/app/pages/home.ts
+++ b/apps/chill-viking-ng-libs/src/app/pages/home.ts
@@ -1,0 +1,1 @@
+export * from './home/home.component';

--- a/apps/chill-viking-ng-libs/src/app/pages/home/home.component.html
+++ b/apps/chill-viking-ng-libs/src/app/pages/home/home.component.html
@@ -3,15 +3,9 @@
     <ng-libs-header [context]="header" [subTitle$]="subTitle$"></ng-libs-header>
   </ng-template>
   <section id="welcome">
-    <h1>Welcome 👋</h1>
-    <p>
-      Welcome to the Chill Viking <code>ng-libs</code> repository! Here, you'll
-      find a variety of high-quality npm packages for Angular projects. Our
-      packages are easy to use and constantly updated to ensure compatibility
-      with the latest version of Angular. Explore our packages and see how they
-      can benefit your projects. We hope you'll join our community and stay
-      up-to-date on the latest developments.
-    </p>
+    <div class="section-title">
+      <h1>Welcome 👋</h1>
+    </div>
     <div class="cta">
       <!-- To be added after packages page created
       <ng-libs-cta [title]="'View available packages'" (clicked)='goToPackages()'></ng-libs-cta>
@@ -25,24 +19,19 @@
         <span>Ask Us a Question</span>
       </ng-libs-cta>
     </div>
-  </section>
-  <section id="overview">
-    <div class="section-title">
-      <h1>Overview</h1>
-    </div>
-    <div class="introduction">
-      <span class="question">
-        Are you tired of tackling common Angular development challenges on your
-        own?
-      </span>
+    <div class="section-body">
       <p>
-        Chill Viking, more specifically this repository, is here to help! Using
-        this repository, we aim to create npm packages that solve problems and
-        make your life easier.
+        Welcome to the Chill Viking <code>ng-libs</code> repository! Here,
+        you'll find a variety of high-quality npm packages for Angular projects.
       </p>
       <p>
-        Check out our offerings and see how we can help you become an Angular
-        pro.
+        Our packages are easy to use and constantly updated to ensure
+        compatibility with the latest version of Angular.
+      </p>
+      <p>
+        Explore our packages and see how they can benefit your projects. We hope
+        you'll join our community and stay up-to-date on the latest
+        developments.
       </p>
     </div>
   </section>

--- a/apps/chill-viking-ng-libs/src/app/pages/home/home.component.html
+++ b/apps/chill-viking-ng-libs/src/app/pages/home/home.component.html
@@ -2,6 +2,30 @@
   <ng-template cvHeader let-header>
     <ng-libs-header [context]="header" [subTitle$]="subTitle$"></ng-libs-header>
   </ng-template>
+  <section id="welcome">
+    <h1>Welcome 👋</h1>
+    <p>
+      Welcome to the Chill Viking <code>ng-libs</code> repository! Here, you'll
+      find a variety of high-quality npm packages for Angular projects. Our
+      packages are easy to use and constantly updated to ensure compatibility
+      with the latest version of Angular. Explore our packages and see how they
+      can benefit your projects. We hope you'll join our community and stay
+      up-to-date on the latest developments.
+    </p>
+    <div class="cta">
+      <!-- To be added after packages page created
+      <ng-libs-cta [title]="'View available packages'" (clicked)='goToPackages()'></ng-libs-cta>
+      -->
+      <ng-libs-cta (clicked)="goToRepository()" type="secondary">
+        <mat-icon>open_in_new</mat-icon>
+        <span>Visit Repository</span>
+      </ng-libs-cta>
+      <ng-libs-cta (clicked)="goToDiscussions()" type="secondary">
+        <mat-icon>open_in_new</mat-icon>
+        <span>Ask Us a Question</span>
+      </ng-libs-cta>
+    </div>
+  </section>
   <section id="overview">
     <div class="section-title">
       <h1>Overview</h1>
@@ -11,7 +35,6 @@
         Are you tired of tackling common Angular development challenges on your
         own?
       </span>
-
       <p>
         Chill Viking, more specifically this repository, is here to help! Using
         this repository, we aim to create npm packages that solve problems and
@@ -21,19 +44,6 @@
         Check out our offerings and see how we can help you become an Angular
         pro.
       </p>
-      <div class="cta">
-        <!-- To be added after packages page created
-        <ng-libs-cta [title]="'View available packages'" (clicked)='goToPackages()'></ng-libs-cta>
-        -->
-        <ng-libs-cta (clicked)="goToRepository()" type="secondary">
-          <mat-icon>open_in_new</mat-icon>
-          <span>Visit Repository</span>
-        </ng-libs-cta>
-        <ng-libs-cta (clicked)="goToDiscussions()" type="secondary">
-          <mat-icon>open_in_new</mat-icon>
-          <span>Ask Us a Question</span>
-        </ng-libs-cta>
-      </div>
     </div>
   </section>
 </cv-layout>

--- a/apps/chill-viking-ng-libs/src/app/pages/home/home.component.scss
+++ b/apps/chill-viking-ng-libs/src/app/pages/home/home.component.scss
@@ -1,49 +1,36 @@
-.cv-layout-container {
-  padding: 0 15px;
+section {
+  display: flex;
+  flex-direction: column;
+  font-size: 1.5em;
+  align-items: center;
+  justify-content: space-evenly;
+  padding: 0 30px;
 
-  section {
-    min-height: 80vh;
+  .cta {
     display: flex;
-    flex-direction: column;
-    font-size: 1.5em;
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-evenly;
 
-    .cta {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: space-between;
-
-      ng-libs-cta {
-        margin-bottom: 15px;
-      }
-
-      mat-icon {
-        margin-right: 10px;
-      }
+    ng-libs-cta {
+      margin-bottom: 15px;
     }
 
-    &#overview {
-      align-items: center;
-      justify-content: space-evenly;
-
-      .question {
-        font-weight: bold;
-      }
-
-      img {
-        max-width: 90%;
-      }
+    mat-icon {
+      margin-right: 10px;
     }
   }
 }
 
-// styles to move into @chill-viking/layout
-cv-layout .cv-layout {
-  max-width: 100vw;
-  width: auto; // max-width to replace currently set width.
+@media (max-width: 600px) {
+  section {
+    padding: 0 15px;
 
-  .cv-layout-container {
-    max-width: 100%;
-    width: auto; // max-width to replace currently set width.
+    .cta {
+      flex-direction: column;
+      align-items: center;
+      justify-content: space-evenly;
+    }
   }
 }

--- a/apps/chill-viking-ng-libs/src/app/routes.ts
+++ b/apps/chill-viking-ng-libs/src/app/routes.ts
@@ -4,6 +4,15 @@ export const rootRoutes: Routes = [
   {
     path: '',
     title: 'Home',
+    data: {
+      metaTags: {
+        description: [
+          'High-quality npm packages for Angular projects.',
+          'Easy to use and constantly updated.',
+          'Explore our packages and join our community.',
+        ].join(' '),
+      },
+    },
     loadComponent: () =>
       import('./pages/home/home.component').then((c) => {
         // Have to use braces to work around prettier's approach of wrapping lines... ffs

--- a/apps/chill-viking-ng-libs/src/app/routes.ts
+++ b/apps/chill-viking-ng-libs/src/app/routes.ts
@@ -13,11 +13,7 @@ export const rootRoutes: Routes = [
         ].join(' '),
       },
     },
-    loadComponent: () =>
-      import('./pages/home/home.component').then((c) => {
-        // Have to use braces to work around prettier's approach of wrapping lines... ffs
-        return c.HomeComponent;
-      }),
+    loadComponent: () => import('./pages/home').then((c) => c.HomeComponent),
   },
 ];
 

--- a/apps/chill-viking-ng-libs/src/index.html
+++ b/apps/chill-viking-ng-libs/src/index.html
@@ -2,8 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>ChillVikingNgLibs</title>
+    <title>Chill Viking | ng-libs</title>
     <base href="/" />
+    <meta name="author" content="chill-viking" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link

--- a/apps/chill-viking-ng-libs/src/main.ts
+++ b/apps/chill-viking-ng-libs/src/main.ts
@@ -1,12 +1,12 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter, TitleStrategy } from '@angular/router';
-import { PageTitleStrategyService } from './app/page-title-strategy.service';
+import { PageMetaDataService } from './app/page-meta-data.service';
 import { RootComponent } from './app/root.component';
 import { rootRouterFeatures, rootRoutes } from './app/routes';
 
 bootstrapApplication(RootComponent, {
   providers: [
     provideRouter(rootRoutes, ...rootRouterFeatures),
-    { provide: TitleStrategy, useClass: PageTitleStrategyService },
+    { provide: TitleStrategy, useClass: PageMetaDataService },
   ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "ng-libs",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## 🎉 Description

Update to set meta tags for page when title set. Will consume meta tags from route `data.metaTags` if set for the current primary navigation.

Fixes #44 

## 🚀 Type of change

- [x] 🆕 New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

- [x] Created temporary routes to confirm route stepping works
- [x] On navigating to home page, description set as defined in route data

## 🧾 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
