### PR TITLE
chore(workflows): add concurrency to CI and CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,16 @@
 on:
   push:
-    branches: ['main']
+    branches: [ 'main' ]
 
 name: CD
 
 permissions:
   contents: write
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, closed]
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, closed ]
   merge_group:
 
 name: CI
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## 🎉 Description

Added to prevent multiple CI and CD workflows running when more than 1 PR merged in quick succession.

Fixes #119 

## 🚀 Type of change

- [x] 🧹 Chore (non-breaking and non-functional change)
