### PR TITLE
chore(workflows): adjust permissions for CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,9 +4,7 @@ on:
 
 name: CD
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 🎉 Description

No longer need permission for writing contents or pull-request, release-please step is using PAT to perform those actions and not workflow token.

Closes #121

## 🚀 Type of change

- [x] 🧹 Chore (non-breaking and non-functional change)
